### PR TITLE
Extend component to support counter prop

### DIFF
--- a/src/Inputs/Input/index.tsx
+++ b/src/Inputs/Input/index.tsx
@@ -30,6 +30,7 @@ interface IInput {
   readOnly?: boolean;
   maxLength?: number;
   minLength?: number;
+  counter?: boolean;
 }
 
 const inputComponents: Record<string, React.ComponentType<IInput>> = {

--- a/src/Inputs/Input/interface.tsx
+++ b/src/Inputs/Input/interface.tsx
@@ -15,6 +15,30 @@ import {
   StyledMessageContainer,
 } from "./styles";
 import { IInput } from ".";
+import { ICounter } from "./props";
+
+const getCounterAppearance = (
+  maxLength: number | undefined,
+  valueLength: number,
+) => {
+  if (!maxLength) return "gray";
+  const lengthThreshold = Math.floor(maxLength * 0.1);
+  if (maxLength - valueLength <= lengthThreshold && valueLength <= maxLength) {
+    return "warning";
+  } else if (valueLength > maxLength) {
+    return "danger";
+  }
+  return "gray";
+};
+
+const Counter = ({ maxLength, currentLength }: ICounter) => {
+  const appearance = getCounterAppearance(maxLength, currentLength);
+  return (
+    <Text type="body" size="small" appearance={appearance} textAlign="start">
+      {maxLength ? `${currentLength}/${maxLength}` : `${currentLength}`}
+    </Text>
+  );
+};
 
 const InputUI = (props: IInput) => {
   const {
@@ -40,6 +64,7 @@ const InputUI = (props: IInput) => {
     value,
     maxLength,
     minLength,
+    counter = false,
   } = props;
 
   const [focusedState, setFocused] = useState(false);
@@ -88,6 +113,8 @@ const InputUI = (props: IInput) => {
     (theme?.input?.message?.appearance as ITextAppearance) ||
     inube.input.message.appearance;
 
+  const currentLength = value ? value.toString().length : 0;
+
   return (
     <StyledContainer $disabled={disabled} $fullwidth={fullwidth} $size={size}>
       <StyledContainerLabel
@@ -119,6 +146,11 @@ const InputUI = (props: IInput) => {
           >
             (Requerido)
           </Text>
+        )}
+        {!disabled && counter && (
+          <Stack justifyContent="flex-end" alignItems="center" width="100%">
+            <Counter maxLength={maxLength} currentLength={currentLength} />
+          </Stack>
         )}
       </StyledContainerLabel>
 

--- a/src/Inputs/Input/props.ts
+++ b/src/Inputs/Input/props.ts
@@ -15,6 +15,11 @@ type IInputSize = (typeof sizes)[number];
 const status = ["invalid", "pending"] as const;
 type IInputStatus = (typeof status)[number];
 
+interface ICounter {
+  maxLength?: number;
+  currentLength: number;
+}
+
 const parameters = {
   docs: {
     description: {
@@ -100,4 +105,4 @@ const props = {
 };
 
 export { parameters, props };
-export type { IInputInputType, IInputSize, IInputStatus };
+export type { IInputInputType, IInputSize, IInputStatus, ICounter };

--- a/src/Inputs/Textfield/stories/Textfield.stories.tsx
+++ b/src/Inputs/Textfield/stories/Textfield.stories.tsx
@@ -25,6 +25,8 @@ Default.args = {
   type: "text",
   size: "wide",
   status: "pending",
+  counter: true,
+  maxLength: 20,
 };
 
 export { Default };


### PR DESCRIPTION
This PR introduces a character counter to the InputUI component controlled by a new counter prop. When enabled, the counter displays the current character count at the top-right corner of the input field. If maxLength is provided, it shows the format `currentLength/maxLength`; otherwise, it displays only the current character count. The counter appearance adapts based on proximity to maxLength, changing to warning or danger colors when approaching or exceeding the limit.