### PR TITLE
Move input tokens from foundations to the Input component

### DIFF
--- a/src/Inputs/Input/interface.tsx
+++ b/src/Inputs/Input/interface.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@inubekit/icon";
 import { Label } from "@inubekit/label";
-import { inube } from "@inubekit/foundations";
+import { inube } from "../Tokens";
 import { ITextAppearance, Text } from "@inubekit/text";
 import { Stack } from "@inubekit/stack";
 import { MdOutlineWarning } from "react-icons/md";

--- a/src/Inputs/Input/styles.js
+++ b/src/Inputs/Input/styles.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
-
-import { inube } from "@inubekit/foundations";
+import { inube } from "../Tokens";
 
 const StyledContainer = styled.div`
   cursor: ${({ $disabled }) => $disabled && "not-allowed"};

--- a/src/Inputs/Tokens/index.ts
+++ b/src/Inputs/Tokens/index.ts
@@ -1,0 +1,9 @@
+import { input } from "./input";
+import { inube as inubeTheme } from "@inubekit/foundations";
+
+const inube = {
+  input,
+  typography: { ...inubeTheme.typography },
+};
+
+export { inube };

--- a/src/Inputs/Tokens/input.ts
+++ b/src/Inputs/Tokens/input.ts
@@ -1,0 +1,47 @@
+import { inube } from "@inubekit/foundations";
+
+const input = {
+  border: {
+    color: {
+      regular: inube.palette.neutral.N40,
+      disabled: inube.palette.neutral.N40,
+      focus: inube.palette.blue.B300,
+      invalid: inube.palette.red.R400,
+    },
+  },
+  background: {
+    color: {
+      regular: inube.palette.neutral.N0,
+      disabled: inube.palette.neutral.N10,
+    },
+  },
+  content: {
+    color: {
+      regular: inube.palette.neutral.N900,
+      disabled: inube.palette.neutral.N70,
+    },
+  },
+  placeholder: {
+    color: {
+      regular: inube.palette.neutral.N300,
+    },
+  },
+  message: {
+    appearance: "danger",
+  },
+  required: {
+    appearance: "danger",
+  },
+  option: {
+    appearance: {
+      regular: "dark",
+      hover: "primary",
+    },
+    background: {
+      regular: inube.palette.neutral.N0,
+      hover: inube.palette.neutral.N30,
+    },
+  },
+};
+
+export { input };


### PR DESCRIPTION
This PR moves the input-related tokens that were previously defined in foundations directly into the Input component. This refactor ensures that the tokens are encapsulated within the component, providing better control over the styles and making the component more self-contained. Additionally, it simplifies the token management by reducing dependencies on external foundations, making it easier to modify and maintain the Input component in the future. All related styling has been updated accordingly to reflect the changes in token placement.